### PR TITLE
Prevent variable expansion in non-production env var check

### DIFF
--- a/common/post-db-copy/post-db-copy.sh
+++ b/common/post-db-copy/post-db-copy.sh
@@ -14,7 +14,7 @@ drush cim --no-interaction
 drush cim --no-interaction
 
 # Sanitize the database (non-production only).
-if [[ -v $AH_NON_PRODUCTION ]]; then
+if [[ -v AH_NON_PRODUCTION ]]; then
   drush sql-sanitize \
     --sanitize-email=%name@example.com \
     --sanitize-password=no


### PR DESCRIPTION
This was the cause of the sanitization failures on backport.  The `AH_NON_PRODUCTION` environment variable was being expanded to "1", which caused the expression to be transformed into (effectively) `if [[ -v 1 ]]; then`.

A variable named `1` does not exist, and thus the test fails.